### PR TITLE
Initial Playlist Card Component

### DIFF
--- a/components/PlaylistCard.js
+++ b/components/PlaylistCard.js
@@ -3,15 +3,12 @@ import Card from 'react-bootstrap/Card';
 import PropTypes from 'prop-types';
 
 function PlaylistCard({ playlistObj }) {
+  console.warn(playlistObj);
   return (
     <Card style={{ width: '18rem' }}>
       <Card.Img variant="top" src={playlistObj.image} />
       <Card.Body>
-        <Card.Title>Card Title</Card.Title>
-        <Card.Text>
-          Some quick example text to build on the card title and make up the
-          bulk of the content.
-        </Card.Text>
+        <Card.Title>{playlistObj.title}</Card.Title>
         <Button variant="primary" className="m-2">VIEW</Button>
         <Button variant="info">EDIT</Button>
         <Button variant="danger" className="m-2">DELETE</Button>
@@ -23,7 +20,6 @@ function PlaylistCard({ playlistObj }) {
 PlaylistCard.propTypes = {
   playlistObj: PropTypes.shape({
     title: PropTypes.string,
-    podcastQuantity: PropTypes.string,
     image: PropTypes.string,
     ownerID: PropTypes.string,
   }).isRequired,

--- a/components/PlaylistCard.js
+++ b/components/PlaylistCard.js
@@ -21,7 +21,7 @@ PlaylistCard.propTypes = {
   playlistObj: PropTypes.shape({
     title: PropTypes.string,
     image: PropTypes.string,
-    ownerID: PropTypes.string,
+    ownerID: PropTypes.number,
   }).isRequired,
 };
 

--- a/components/PlaylistCard.js
+++ b/components/PlaylistCard.js
@@ -1,9 +1,32 @@
-import React from 'react';
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+import PropTypes from 'prop-types';
 
-export default async function PlaylistCard() {
+function PlaylistCard({ playlistObj }) {
   return (
-    <div>
-      This is a playlist card
-    </div>
+    <Card style={{ width: '18rem' }}>
+      <Card.Img variant="top" src={playlistObj.image} />
+      <Card.Body>
+        <Card.Title>Card Title</Card.Title>
+        <Card.Text>
+          Some quick example text to build on the card title and make up the
+          bulk of the content.
+        </Card.Text>
+        <Button variant="primary" className="m-2">VIEW</Button>
+        <Button variant="info">EDIT</Button>
+        <Button variant="danger" className="m-2">DELETE</Button>
+      </Card.Body>
+    </Card>
   );
 }
+
+PlaylistCard.propTypes = {
+  playlistObj: PropTypes.shape({
+    title: PropTypes.string,
+    podcastQuantity: PropTypes.string,
+    image: PropTypes.string,
+    ownerID: PropTypes.string,
+  }).isRequired,
+};
+
+export default PlaylistCard;

--- a/pages/playlists.js
+++ b/pages/playlists.js
@@ -1,26 +1,25 @@
-// import { useEffect, useState } from 'react';
-// import { getSinglePlaylist } from '../api/playlistData';
+import { useEffect, useState } from 'react';
+import { useAuth } from '../utils/context/authContext';
+import { getAllPlaylists } from '../api/playlistData';
+import PlaylistCard from '../components/PlaylistCard';
 
 export default function ViewPlaylists() {
-  // const [data, setData] = useState(null);
+  const [playlists, setPlaylists] = useState([]);
+  const { user } = useAuth();
+  const getAllUserPlaylists = () => {
+    getAllPlaylists(user.uid).then(setPlaylists);
+  };
 
-  // useEffect(() => {
-  //   const fetchData = async () => {
-  //     try {
-  //       const response = await getSinglePlaylist(1);
-  //       console.warn(response);
-  //       setData(response);
-  //     } catch (error) {
-  //       console.error('Error fetching data:', error);
-  //     }
-  //   };
-
-  //   fetchData();
-  // }, []);
+  useEffect(() => {
+    getAllUserPlaylists();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
-    <div>
-      This is to view playlist cards
+    <div className="d-flex flex-wrap">
+      {playlists.map((playlist) => (
+        <PlaylistCard key={playlist.ownerID} playlistObj={playlist} onUpdate={getAllUserPlaylists} />
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
## Description
This is for the initial playlist card component to render the individual playlist cards to the DOM. This includes the playlist card component and the playlists.js page.

## Related Issue
#9 #11 

## Motivation and Context
This is needed for the user to be able to view individual playlists, and will be used for the update/create and view playlist details.

## How Can This Be Tested?
Pulling down the branch ->
npm run dev ->
select playlists from the nav bar ->
playlist cards should be rendered with broken image links (this will be updated later)

## Screenshots (if appropriate): 
The "string" cards should only be local to my machine after ensuring api calls worked in postman before coding. 
![Screenshot 2024-04-27 at 10 29 15 AM](https://github.com/taylorseager/podcast-player/assets/154686027/40c3d339-225d-4de6-abe3-bf7c9c9e827a)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
