### PR TITLE
Delete functionality working

### DIFF
--- a/api/playlistData.js
+++ b/api/playlistData.js
@@ -75,8 +75,8 @@ const deletePlaylist = (id) => new Promise((resolve, reject) => {
       'Content-Type': 'application/json',
     },
   })
-    .then((response) => response.json())
-    .then((data) => resolve((data)))
+    .then((response) => response.text())
+    .then((data) => resolve(data))
     .catch(reject);
 });
 

--- a/components/PlaylistCard.js
+++ b/components/PlaylistCard.js
@@ -1,9 +1,15 @@
 import Button from 'react-bootstrap/Button';
 import Card from 'react-bootstrap/Card';
 import PropTypes from 'prop-types';
+import { deletePlaylist } from '../api/playlistData';
 
-function PlaylistCard({ playlistObj }) {
-  console.warn(playlistObj);
+function PlaylistCard({ playlistObj, onUpdate }) {
+  const deleteThisPlaylist = () => {
+    if (window.confirm(`Are you 1000% positive you want to delete ${playlistObj.title}? This action cannot be undone.`)) {
+      deletePlaylist(playlistObj.id).then(() => onUpdate());
+    }
+  };
+
   return (
     <Card style={{ width: '18rem' }}>
       <Card.Img variant="top" src={playlistObj.image} />
@@ -12,7 +18,7 @@ function PlaylistCard({ playlistObj }) {
         <p>Playlist Quantity: {playlistObj.podcastQuantity}</p>
         <Button variant="primary" className="m-2">VIEW</Button>
         <Button variant="info">EDIT</Button>
-        <Button variant="danger" className="m-2">DELETE</Button>
+        <Button variant="danger" onClick={deleteThisPlaylist} className="m-2">DELETE</Button>
       </Card.Body>
     </Card>
   );
@@ -20,11 +26,13 @@ function PlaylistCard({ playlistObj }) {
 
 PlaylistCard.propTypes = {
   playlistObj: PropTypes.shape({
+    id: PropTypes.number,
     title: PropTypes.string,
     image: PropTypes.string,
     podcastQuantity: PropTypes.string,
     ownerID: PropTypes.number,
   }).isRequired,
+  onUpdate: PropTypes.func.isRequired,
 };
 
 export default PlaylistCard;


### PR DESCRIPTION
## Description
The delete button on the individual playlist cards is correctly removing playlists from the database.

## Related Issue
#14 

## Motivation and Context
This allows users to delete playlists from their account.

## How Can This Be Tested?
Pulling down the branch ->
npm run dev ->
select playlists from the nav bar ->
playlist cards should be rendered ->
select delete button -> 
pop-up window to confirm delete will show up ->
click 'OK' ->
playlist card should be deleted from DOM (and database)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
