### PR TITLE
Add Podcast to Playlist

### DIFF
--- a/components/PodcastCard.js
+++ b/components/PodcastCard.js
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import PropTypes from 'prop-types';
 import { Button, Card } from 'react-bootstrap';
 
@@ -16,7 +17,9 @@ export default function PodcastCard({ podcastObj }) {
         <Card.Text>
           Length: {podcastObj.length} Minutes
         </Card.Text>
-        <Button variant="primary">Add to Playlist</Button>
+        <Link passHref href={`podcast/${podcastObj.id}`}>
+          <Button variant="primary">Add to Playlist</Button>
+        </Link>
       </Card.Body>
     </Card>
   );

--- a/components/forms/AddToPlaylistForm.js
+++ b/components/forms/AddToPlaylistForm.js
@@ -1,0 +1,28 @@
+// import { useRouter } from 'next/router';
+// import React, { useEffect, useState } from 'react';
+// import { Button, Form } from 'react-bootstrap';
+// import { useAuth } from '../../utils/context/authContext';
+// import { getAllPlaylists } from '../../api/playlistData';
+
+// export default function AddToPlaylistForm({ playlistObj }) {
+//   const [formInput, setFormInput] = useState(initialState);
+//   const [playlists, setPlaylists] = useState([]);
+//   const router = useRouter();
+//   const { user } = useAuth();
+
+//   useEffect(() => {
+//     getAllPlaylists(user.ownerID);
+//   });
+//   return (
+//     <>
+//       <Form>
+//         <Form.Group className="mb-3" controlId="playlistCheckbox">
+//           <Form.Check type="checkbox" label="Check me out" />
+//         </Form.Group>
+//         <Button variant="primary" type="submit">
+//           Submit
+//         </Button>
+//       </Form>
+//     </>
+//   );
+// }

--- a/components/forms/AddToPlaylistForm.js
+++ b/components/forms/AddToPlaylistForm.js
@@ -1,28 +1,43 @@
 // import { useRouter } from 'next/router';
-// import React, { useEffect, useState } from 'react';
-// import { Button, Form } from 'react-bootstrap';
-// import { useAuth } from '../../utils/context/authContext';
-// import { getAllPlaylists } from '../../api/playlistData';
+import React, { useEffect, useState } from 'react';
+import { Button, Form } from 'react-bootstrap';
+import { useAuth } from '../../utils/context/authContext';
+import { getAllPlaylists } from '../../api/playlistData';
 
-// export default function AddToPlaylistForm({ playlistObj }) {
-//   const [formInput, setFormInput] = useState(initialState);
-//   const [playlists, setPlaylists] = useState([]);
-//   const router = useRouter();
-//   const { user } = useAuth();
+export default function AddToPlaylistForm() {
+  // const [formInput, setFormInput] = useState(initialState);
+  const [playlists, setPlaylists] = useState([]);
+  // const router = useRouter();
+  const { user } = useAuth();
 
-//   useEffect(() => {
-//     getAllPlaylists(user.ownerID);
-//   });
-//   return (
-//     <>
-//       <Form>
-//         <Form.Group className="mb-3" controlId="playlistCheckbox">
-//           <Form.Check type="checkbox" label="Check me out" />
-//         </Form.Group>
-//         <Button variant="primary" type="submit">
-//           Submit
-//         </Button>
-//       </Form>
-//     </>
-//   );
-// }
+  useEffect(() => {
+    getAllPlaylists(user.ownerID).then(setPlaylists);
+
+    // FINISH IF STATEMENT TO PREPOPULATE PLAYLISTS THAT PODCAST IS ALREADY ON
+    // if (playlistObj.id) {
+    //   setFormInput(playlistObj);
+    // }
+  }, [user]);
+  return (
+    <>
+      <Form>
+        <Form.Group className="mb-3" controlId="playlistCheckbox">
+          {
+            playlists.map((playlist) => (
+              <Form.Check
+                type="checkbox"
+                id="id"
+                name="id"
+                label={playlist.title}
+                key={playlist.id}
+              />
+            ))
+          }
+        </Form.Group>
+        <Button variant="primary" type="submit">
+          Submit
+        </Button>
+      </Form>
+    </>
+  );
+}

--- a/pages/podcast.js/[id].js
+++ b/pages/podcast.js/[id].js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function addToPlaylist() {
+  return (
+    <div>
+      This will display the form to add podcasts to playlists
+    </div>
+  );
+}

--- a/pages/podcast.js/[id].js
+++ b/pages/podcast.js/[id].js
@@ -1,9 +1,0 @@
-import React from 'react';
-
-export default function addToPlaylist() {
-  return (
-    <div>
-      This will display the form to add podcasts to playlists
-    </div>
-  );
-}

--- a/pages/podcast/[id].js
+++ b/pages/podcast/[id].js
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from 'react';
+// import { useRouter } from 'next/router';
+import AddToPlaylistForm from '../../components/forms/AddToPlaylistForm';
+import { getAllPlaylists } from '../../api/playlistData';
+import { useAuth } from '../../utils/context/authContext';
+
+export default function AddToPlaylist() {
+  const [addToPlaylist, setAddToPlaylist] = useState({});
+  // const router = useRouter();
+  // const { id } = router.query;
+  const { user } = useAuth();
+
+  useEffect(() => {
+    getAllPlaylists(user.ownerID).then(setAddToPlaylist);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return (
+    <>
+      <h1>Add to Your Playlist!</h1>
+      <AddToPlaylistForm playlistObj={addToPlaylist} />
+    </>
+  );
+}


### PR DESCRIPTION
## Description
- Created AddToPlaylistForm.js file
- Created form to check which playlists to add the podcast to
- Created podcast directory
- Created dynamic podcast file to pull add to playlist form that will allow prepopulation of playlists the podcast is already on once the functionality is built 
-
## Related Issue
#17 

## Motivation and Context
This change is required so that users can add podcasts to their playlists.
Form structure/content is build. Functionality of the form (prepopulation + handling submit) still needs to be built.

## How Can This Be Tested?
Login ->
Click Podcasts ->
Click Add To Playlist Button ->
Confirm that you see the checklist of playlists

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
