### PR TITLE
Bug fixes related to PodcastQuantity

### DIFF
--- a/api/playlistData.js
+++ b/api/playlistData.js
@@ -116,6 +116,27 @@ const incrementPodcastQuantity = (playlistId) => new Promise((resolve, reject) =
   .catch(reject);
 });
 
+// Decrements Podcast Quantity on a Playlist
+const decrementPodcastQuantity = (playlistId) => new Promise((resolve, reject) => {
+  console.log(`Attempting to decrement podcast quantity for playlist ID: ${playlistId}`);
+  fetch(`${endpoint}/api/decrementPodcastQuantity/${playlistId}`, {
+    method: 'PATCH', 
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+  .then(response => {
+    if (response.ok) {
+      // Process the response if it's OK
+      return response.json(); 
+    }
+    // Throw an error if response not OK
+    throw new Error('Failed to decrement podcast quantity'); 
+  })
+  .then(data => resolve(data))
+  .catch(reject);
+});
+
 export {
   getAllPlaylists,
   getSinglePlaylist,
@@ -125,4 +146,5 @@ export {
   deletePlaylist,
   getSinglePlaylistByTitle,
   incrementPodcastQuantity,
+  decrementPodcastQuantity,
 };

--- a/components/PodcastCard.js
+++ b/components/PodcastCard.js
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Button, Card } from 'react-bootstrap';
 import { useRouter } from 'next/router';
 import { deletePodcastfromPlaylist, viewPlaylistDetails } from '../api/mergedData';
+import { decrementPodcastQuantity } from '../api/playlistData';
 
 export default function PodcastCard({ podcastObj, onUpdate }) {
   const [playlistDetails, setPlaylistDetails] = useState({});
@@ -16,6 +17,7 @@ export default function PodcastCard({ podcastObj, onUpdate }) {
 
   const removeThisPodcast = () => {
     if (window.confirm(`Remove ${podcastObj.name}?`)) {
+      decrementPodcastQuantity(playlistDetails.id);
       deletePodcastfromPlaylist(playlistDetails.id, podcastObj.id).then(() => onUpdate());
     }
   };

--- a/components/forms/AddToPlaylistForm.js
+++ b/components/forms/AddToPlaylistForm.js
@@ -47,6 +47,9 @@ export default function AddToPlaylistForm() {
 
         return Promise.all(relationshipPromises);
       })
+      .then(() => {
+        router.push('/playlists');
+      })
       .catch((error) => {
         console.error('Error processing details or relationships:', error);
       });

--- a/pages/playlists.js
+++ b/pages/playlists.js
@@ -9,6 +9,7 @@ export default function ViewPlaylists() {
   const getAllUserPlaylists = () => {
     getAllPlaylists(user.uid).then(setPlaylists);
   };
+  // Fixes a bug with rendering the correct Podcast Quantity
 
   useEffect(() => {
     getAllUserPlaylists();


### PR DESCRIPTION
Added functionality for decreasing playlist quantity when a podcast is removed from a playlist. Also tweaked the playlists page to fix a bug that was causing a delay between the data the front end was displaying and the data the back end was showing.